### PR TITLE
Reword debug prints and add formula substitution

### DIFF
--- a/rumm/Cargo.toml
+++ b/rumm/Cargo.toml
@@ -13,6 +13,6 @@ logos = "0.12.0"
 chrono = "0.4"
 colored = "2"
 simple_logger = "1.13.0"
-# metamath-knife = { path = "../../metamath-knife" }
+metamath-knife = { path = "../../metamath-knife" }
 # metamath-knife = { git = "https://github.com/tirix/metamath-knife", tag="v0.3.6"}
-metamath-knife = { git = "https://github.com/david-a-wheeler/metamath-knife", tag="v0.3.6"}
+# metamath-knife = { git = "https://github.com/david-a-wheeler/metamath-knife", tag="v0.3.6"}

--- a/rumm/examples/set.rmm
+++ b/rumm/examples/set.rmm
@@ -5,6 +5,13 @@ load "examples/examples.mm"
 tactics deduction ()
 { try
 	!
+	{ match goal
+		$ ( &W1 -> ( &W2 /\ &W3 ) ) $
+		{ apply ~jca { use deduction } { use deduction } }
+		$ ( &W1 -> ( &W2 /\ &W3 /\ &W4 ) ) $
+		{ apply ~3jca { use deduction } { use deduction } { use deduction } }
+	}
+	{ apply ~id }
 	{ apply ~a1i ! }
 	{ apply ~simpr }
 	{ apply ~simpl }
@@ -42,6 +49,10 @@ tactics equality ()
 		$ ( ph -> ( A. x e. A ps <-> A. x e. A ch ) ) $ { apply ~ralbidv { use equality } }
 		$ ( ph -> ( A. x e. A ps <-> A. x e. B ps ) ) $ { apply ~raleqdv { use equality } }
 		$ ( ph -> ( A. x e. A ps <-> A. x e. B ch ) ) $ { apply ~raleqbidv { use equality } { use equality } }
+		$ ( ph -> ( E. x ps <-> E. x ch ) ) $ { apply ~exbid { use equality } }
+		$ ( ph -> ( E. x e. A ps <-> E. x e. A ch ) ) $ { apply ~rexbidv { use equality } }
+		$ ( ph -> ( E. x e. A ps <-> E. x e. B ps ) ) $ { apply ~rexeqdv { use equality } }
+		$ ( ph -> ( E. x e. A ps <-> E. x e. B ch ) ) $ { apply ~rexeqbidv { use equality } { use equality } }
 		$ ( ph -> ( A e. B <-> C e. B ) ) $ { apply ~eleq1d { use equality } }
 		$ ( ph -> ( A e. B <-> A e. C ) ) $ { apply ~eleq2d { use equality } }
 		$ ( ph -> ( A e. B <-> C e. D ) ) $ { apply ~eleq12d { use equality } { use equality } }
@@ -61,7 +72,20 @@ tactics equality ()
 		$ ( ph -> { x e. A | ps } = { x e. A | ch } ) $ { apply ~rabbidv { use equality } }
 		$ ( ph -> { <. x , y >. | ps } = { <. x , y >. | ch } ) $ { apply ~opabbidv { use equality } }
 
-		$ ( ( ph /\ x = X ) -> ( F ` x ) = B ) $ { apply ~syl6eqr { use equality } ! with ~cB $ ( F ` X ) $ }
+		$ ( ph -> ( x e. A |-> B ) = ( x e. C |-> B ) ) $ { apply ~mpteq1d { use equality } }
+		$ ( ph -> ( x e. A |-> B ) = ( x e. A |-> C ) ) $ { apply ~mpteq2dv { use equality } }
+		$ ( ph -> ( x e. A |-> B ) = ( x e. C |-> D ) ) $ { apply ~mpteq12dv { use equality } { use equality } }
+
+		$ ( ph -> if ( &W1 , &C1 , &C2 ) = if ( &W1 , &C3 , &C2 ) ) $ { apply ~ifeq1d { use equality }  }
+		$ ( ph -> if ( &W1 , &C1 , &C2 ) = if ( &W1 , &C1 , &C3 ) ) $ { apply ~ifeq2d { use equality }  }
+		$ ( ph -> if ( &W1 , &C1 , &C2 ) = if ( &W1 , &C3 , &C4 ) ) $ { apply ~ifeq12d { use equality }  }
+		$ ( ph -> if ( &W1 , &C1 , &C2 ) = if ( &W2 , &C1 , &C2 ) ) $ { apply ~ifbid { use equality }  }
+		$ ( ph -> if ( &W1 , &C1 , &C2 ) = if ( &W2 , &C3 , &C2 ) ) $ { apply ~ifbieq1d { use equality }  }
+		$ ( ph -> if ( &W1 , &C1 , &C2 ) = if ( &W2 , &C1 , &C3 ) ) $ { apply ~ifbieq2d { use equality }  }
+		$ ( ph -> if ( &W1 , &C1 , &C2 ) = if ( &W2 , &C3 , &C4 ) ) $ { apply ~ifbieq12d { use equality }  }
+
+		$ ( ( ph /\ X = Y ) -> &C1 = &C2 ) $ { apply ~syl6eqr { use equality } ! with ~cB s/ $ X $ / $ Y $ / $ &C1 $ }
+		$ ( X = Y -> &C1 = &C2 ) $ { apply ~syl6eqr { use equality } ! with ~cB s/ $ X $ / $ Y $ / $ &C1 $ }
 	}
 }
 
@@ -125,27 +149,13 @@ tactics deduction_apply ( ≈THM @T )
 { match statement ≈THM
 	$ ( &W1 -> ( &W2 /\ &W3 ) ) $
 	{ match goal 
-		$ ( &W4 -> &W2 ) $
-		{ subgoal
-			{ apply ~simpld @T } // Here the second term is unknown and there is no way for Rumm to guess it
-			$ ( &W1 -> &W2 ) $
-			{ use deduction }
-		}
-		$ ( &W4 -> &W3 ) $
-		{ subgoal
-			{ apply ~simprd @T } // Here the first term is unknown and there is no way for Rumm to guess it
-			$ ( &W1 -> &W2 ) $
-			{ use deduction }
-		}
+		$ ( &W4 -> &W2 ) $ { apply ~syl { use deduction } { apply ~simpld @T with ~wch $ &W3 $ } with ~wps $ &W1 $ }
+		$ ( &W4 -> &W3 ) $ { apply ~syl { use deduction } { apply ~simprd @T with ~wch $ &W2 $ } with ~wps $ &W1 $ }
 	}
 	$ ( &W1 -> &W2 ) $
 	{ match goal 
 		$ ( &W4 -> &W2 ) $
-		{ subgoal
-			@T
-			$ ( &W1 -> &W2 ) $
-			{ use deduction }
-		}
+		{ apply ~syl { use deduction } @T with ~wps $ &W1 $ }
 	}
 }
 
@@ -179,12 +189,17 @@ proof ~inftmrel
 	with ~cB $ { <. x , y >. | ( ( x e. B /\ y e. B ) /\ ( ( 0g ` W ) ( lt ` W ) x /\ A. n e. NN ( n ( .g ` W ) x ) ( lt ` W ) y ) ) } $
 }
 
-// WIP
-// proof ~ellimc
-// { subgoal
-// 	{ use deduction_apply ~limcfval { apply ~limcfval { use deduction } { use deduction } } }
-//	$ ( ph -> ( C e. ( F limCC B ) <-> C e. { y | ( z e. ( A u. { B } ) |-> if ( z = B , y , ( F ` z ) ) ) e. ( ( J CnP K ) ` B ) } ) ) $
-//	{ apply ~bitrd 
-//		?
-//	}
-// }
+proof ~ellimc
+{ apply ~bitrd
+	{ subgoal 
+		{ use deduction_apply ~limcfval { apply ~limcfval { use deduction } { use deduction } } }
+		$ ( ph -> ( F limCC B ) = { y | ( z e. ( A u. { B } ) |-> if ( z = B , y , ( F ` z ) ) ) e. ( ( J CnP K ) ` B ) } ) $
+		{ use equality }
+	}
+	{ apply ~syl
+		{ use deduction_apply ~limcvallem { apply ~limcvallem ! ! ! with ~vz $ z $ } }
+		{ apply ~elab3g { use equality } }
+		with ~wps $ ( G e. ( ( J CnP K ) ` B ) -> C e. CC ) $
+	}
+	with ~wch $ C e. { y | ( z e. ( A u. { B } ) |-> if ( z = B , y , ( F ` z ) ) ) e. ( ( J CnP K ) ` B ) } $
+}

--- a/rumm/src/parser.rs
+++ b/rumm/src/parser.rs
@@ -36,6 +36,12 @@ pub enum Token {
     #[token("statement")]
     StatementKeyword,
 
+    #[token("s/")]
+    BeginSubstitutionKeyword,
+
+    #[token("/")]
+    SubstitutionKeyword,
+
     #[token("with")]
     WithKeyword,
 

--- a/rumm/src/tactics/hypothesis.rs
+++ b/rumm/src/tactics/hypothesis.rs
@@ -36,10 +36,10 @@ impl Tactics for Hypothesis {
     }
 
     fn execute(&self, context: &mut Context) -> TacticsResult {
-        println!("-- ! --");
+        context.enter("!");
         for (label, hyp) in context.hypotheses().iter() {
             if context.goal().eq(hyp) {
-                println!("Matched hypothesis!");
+                context.exit("Matched hypothesis!");
                 return Ok(ProofStep::hyp(
                     *label,
                     context.goal().clone(),
@@ -48,11 +48,11 @@ impl Tactics for Hypothesis {
         }
         for (hyp, step) in context.subgoals().iter() {
             if context.goal().eq(hyp) {
-                println!("Matched subgoal!");
+                context.exit("Matched subgoal!");
                 return Ok(step.clone());
             }
         }
-        println!("Hypothesis failed");
+        context.exit("Hypothesis failed");
         Err(TacticsError::Error)
     }
 }

--- a/rumm/src/tactics/skipped.rs
+++ b/rumm/src/tactics/skipped.rs
@@ -34,8 +34,9 @@ impl Tactics for Skipped {
         "The \"to do\" tactics, leaving the goal unproven and filling in the Metamath proof with an incomplete, question mark proof.".to_string()
     }
 
-    fn execute(&self, _context: &mut Context) -> TacticsResult {
-        println!("Skipped!");
+    fn execute(&self, context: &mut Context) -> TacticsResult {
+        context.enter("Skip");
+        context.exit("Skipped!");
         Err(TacticsError::Error)
     }
 }

--- a/rumm/src/tactics/subgoal.rs
+++ b/rumm/src/tactics/subgoal.rs
@@ -52,13 +52,16 @@ impl Tactics for Subgoal {
     }
 
     fn execute(&self, mut context: &mut Context) -> TacticsResult {
-        println!("-- Subgoal --");
+        context.enter("Subgoal");
         let subgoal = self.subgoal.substitute(context.variables());
         let mut context1 = context.with_goal(subgoal.clone());
         if let Ok(step1) = self.tactics1.execute(&mut context1) {
             context.add_subgoal(subgoal, step1);
-            self.tactics2.execute(&mut context)
+            let res = self.tactics2.execute(&mut context);
+            context.exit("Subgoal complete");
+            res
         } else {
+            context.exit("-- Subgoal failed --");
             Err(TacticsError::Error)
         }
     }

--- a/rumm/src/tactics/try.rs
+++ b/rumm/src/tactics/try.rs
@@ -44,12 +44,14 @@ impl Tactics for Try {
     }
 
     fn execute(&self, context: &mut Context) -> TacticsResult {
-        println!("-- Try --");
+        context.enter("Try");
         for t in &self.tactics {
             if let Ok(step) = t.execute(context) {
+                context.exit("Try Successful");
                 return Ok(step);
             }
         }
+        context.exit("-- Try Failed --");
         Err(TacticsError::Error)
     }
 }

--- a/rumm/src/tactics/use_script_tactics.rs
+++ b/rumm/src/tactics/use_script_tactics.rs
@@ -41,14 +41,16 @@ impl Tactics for UseScriptTactics {
     }
 
     fn execute(&self, context: &mut Context) -> TacticsResult {
-        println!("-- Use {} --", self.name);
+        context.enter(&format!("Use {}", self.name));
         if let Some(tactics_definition) = context.clone().get_tactics_definition(self.name.clone())
         {
             let mut sub_context = context.without_variables();
             tactics_definition.add_variables(&mut sub_context, &self.parameters)?;
-            tactics_definition.execute(&mut sub_context)
+            let res = tactics_definition.execute(&mut sub_context);
+            context.exit(&format!("{} complete", self.name));
+            res
         } else {
-            println!("-- {} failed --", self.name);
+            context.exit(&format!("{} failed", self.name));
             Err(TacticsError::Error)
         }
     }


### PR DESCRIPTION
This improves the readability of debug prints by adding indentation.
Adds a new "substitution" construct for formulas.
A third theorem `ellimc` can now be proven using the updated tactics.