### PR TITLE
typo

### DIFF
--- a/rumm.md
+++ b/rumm.md
@@ -66,7 +66,7 @@ syl $p |- ( ph -> ch ) $= ( wi a1i mpd ) ABCDBCFAEGH $.
 ```
 Since `~syl`'s final statement, `( ph -> ch )`, does not include the `ps` wff variable, one has to provide it manually using the `with` keyword.
 ```
-{ apply ~syl ! ! with ~ps $ A e. V $ }
+{ apply ~syl ! ! with ~wps $ A e. V $ }
 ```
 
 ---


### PR DESCRIPTION
The `apply` tactic requires a statement label after `with`. Therefore, if I want to specify the substitution for `ps`, I need to provide its corresponding label, which in this case is `wps`.